### PR TITLE
android build add customized key cfg option

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -15,19 +15,54 @@ android {
         minSdkVersion 24
     }
 
-    signingConfigs {
+    def use_default_release_cfg = false
 
-        release {
-            storeFile file(RELEASE_STORE_FILE)
-            storePassword RELEASE_STORE_PASSWORD
-            keyAlias RELEASE_KEY_ALIAS
-            keyPassword RELEASE_KEY_PASSWORD
+    if (use_default_release_cfg) {
+        signingConfigs {
 
-            // Optional, specify signing versions used
-            v1SigningEnabled true
-            v2SigningEnabled true
+            release {
+                storeFile file(RELEASE_STORE_FILE)
+                storePassword RELEASE_STORE_PASSWORD
+                keyAlias RELEASE_KEY_ALIAS
+                keyPassword RELEASE_KEY_PASSWORD
+
+                // Optional, specify signing versions used
+                v1SigningEnabled true
+                v2SigningEnabled true
+            }
         }
     }
+    else {
+        def savePosition = "nab.keystore"
+        def key = "default"
+        def storePass = "default"
+        def keyPass = "default"
+
+        if (project.hasProperty("KEY_ALIAS")) {
+            key = KEY_ALIAS
+        }
+        if (project.hasProperty("STORE_PASSWORD")) {
+            storePass = STORE_PASSWORD
+        }
+        if (project.hasProperty("KEY_PASSWORD")) {
+            keyPass = KEY_PASSWORD
+        }
+        signingConfigs {
+
+            release {
+                storeFile file(savePosition)
+                keyAlias key
+                storePassword storePass
+                keyPassword keyPass
+
+                // Optional, specify signing versions used
+                v1SigningEnabled true
+                v2SigningEnabled true
+            }
+        }
+    }
+
+
     buildTypes {
         release {
             signingConfig signingConfigs.release


### PR DESCRIPTION
增加了一种临时设定keystore的方式，小白更容易上手使用

在小米8上执行了测试，结果如下

![screenshot_mi8](https://user-images.githubusercontent.com/3831847/84751918-b65fd600-afef-11ea-8215-0fe222601926.png)
